### PR TITLE
Give library public visibility in bazel

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -11,7 +11,7 @@ cc_library(
         "@abseil-cpp//absl/container:flat_hash_map",
         "@fmt//:fmt"
     ],
-    visibility = ["//tests:__pkg__"]
+    visibility = ["//visibility:public"]
 )
 
 cc_proto_library(


### PR DESCRIPTION
We want users of this package to see it.