### PR TITLE
No need to call ShutdownProtobufLibrary

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -250,8 +250,6 @@ absl::Status compute_graph_ad::to_file(const Graph& graph, fs::path path) {
                       path.string())));
   }
 
-  google::protobuf::ShutdownProtobufLibrary();
-
   return ret_status;
 }
 
@@ -269,7 +267,6 @@ absl::StatusOr<Graph> compute_graph_ad::from_file(fs::path path) {
 
     const bool ok = gproto.ParseFromIstream(&in_file);
     if (!ok) {
-      google::protobuf::ShutdownProtobufLibrary();
       return absl::AbortedError(
           fmt::format("Something went wrong while serializing Graph to file {}",
                       path.string()));


### PR DESCRIPTION
I had added it to make sure leak checkers would see no leaks, because of the comment at the bottom of
https://protobuf.dev/getting-started/cpptutorial/#writing-a-message. However, Valgrind says there are no leaks even
without it.

Note that the code removed was wrong anyways:
in from_file, the function was only called in
case of errors. Thanks Martin!