### PR TITLE
Simplify `to_proto` call chain

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -20,30 +20,6 @@ using namespace compute_graph_ad;
 namespace gpb = graph_proto;
 
 namespace {
-gpb::Graph* make_proto_graph(gpb::Graph::OpCase optype, void* opptr) {
-  auto* gproto = new gpb::Graph();  // caller will take ownership
-
-  switch (optype) {
-    case gpb::Graph::OpCase::kSum:
-      gproto->set_allocated_sum(static_cast<gpb::Sum*>(opptr));
-      break;
-    case gpb::Graph::OpCase::kMul:
-      gproto->set_allocated_mul(static_cast<gpb::Mul*>(opptr));
-      break;
-    case gpb::Graph::OpCase::kVar:
-      gproto->set_allocated_var(static_cast<gpb::Var*>(opptr));
-      break;
-    case gpb::Graph::OpCase::kConst:
-      gproto->set_allocated_const_(static_cast<gpb::Const*>(opptr));
-      break;
-    case gpb::Graph::OpCase::OP_NOT_SET:
-      std::abort();  // TODO and log: this should never happen
-      break;
-  }
-
-  return gproto;
-}
-
 std::unique_ptr<const Op> op_from_proto(const gpb::Graph& gproto) {
   std::unique_ptr<const Op> op;
 
@@ -106,20 +82,15 @@ float Sum::eval_grad(const Inputs& inputs,
   return value1 + value2;
 }
 
-std::pair<gpb::Graph::OpCase, void*> Sum::to_proto() const noexcept {
-  auto* sum = new gpb::Sum();  // caller will take ownership
+gpb::Graph Sum::to_proto() const noexcept {
+  gpb::Sum sum;
+  *sum.mutable_op1() = op1->to_proto();
+  *sum.mutable_op2() = op2->to_proto();
 
-  // op1
-  auto [op1type, op1ptr] = op1->to_proto();
-  gpb::Graph* g1 = make_proto_graph(op1type, op1ptr);
-  sum->set_allocated_op1(g1);
+  gpb::Graph ret;
+  *ret.mutable_sum() = std::move(sum);
 
-  // op2
-  auto [op2type, op2ptr] = op2->to_proto();
-  gpb::Graph* g2 = make_proto_graph(op2type, op2ptr);
-  sum->set_allocated_op2(g2);
-
-  return {gpb::Graph::OpCase::kSum, sum};
+  return ret;
 }
 
 std::unique_ptr<Sum> Sum::from_proto(const gpb::Sum& sproto) noexcept {
@@ -154,20 +125,15 @@ float Mul::eval_grad(const Inputs& inputs,
   return value1 * value2;
 }
 
-std::pair<gpb::Graph::OpCase, void*> Mul::to_proto() const noexcept {
-  auto* mul = new gpb::Mul();  // caller will take ownership
+gpb::Graph Mul::to_proto() const noexcept {
+  gpb::Mul mul;
+  *mul.mutable_op1() = op1->to_proto();
+  *mul.mutable_op2() = op2->to_proto();
 
-  // op1
-  auto [op1type, op1ptr] = op1->to_proto();
-  gpb::Graph* g1 = make_proto_graph(op1type, op1ptr);
-  mul->set_allocated_op1(g1);
+  gpb::Graph ret;
+  *ret.mutable_mul() = std::move(mul);
 
-  // op2
-  auto [op2type, op2ptr] = op2->to_proto();
-  gpb::Graph* g2 = make_proto_graph(op2type, op2ptr);
-  mul->set_allocated_op2(g2);
-
-  return {gpb::Graph::OpCase::kMul, mul};
+  return ret;
 }
 
 std::unique_ptr<Mul> Mul::from_proto(const gpb::Mul& mproto) noexcept {
@@ -197,10 +163,14 @@ float Const::eval_grad(
   return value;
 }
 
-std::pair<gpb::Graph::OpCase, void*> Const::to_proto() const noexcept {
-  auto* c = new gpb::Const();  // caller will take ownership
-  c->set_value(value);
-  return {gpb::Graph::OpCase::kConst, c};
+gpb::Graph Const::to_proto() const noexcept {
+  gpb::Const c;
+  c.set_value(value);
+
+  gpb::Graph ret;
+  *ret.mutable_const_() = std::move(c);
+
+  return ret;
 }
 
 std::unique_ptr<Const> Const::from_proto(const gpb::Const& cproto) noexcept {
@@ -227,21 +197,21 @@ float Var::eval_grad(const Inputs& inputs,
   return eval(inputs);
 }
 
-std::pair<gpb::Graph::OpCase, void*> Var::to_proto() const noexcept {
-  auto* var = new gpb::Var();  // caller will take ownership
-  var->set_name(name);
-  return {gpb::Graph::OpCase::kVar, var};
+gpb::Graph Var::to_proto() const noexcept {
+  gpb::Var var;
+  var.set_name(name);
+
+  gpb::Graph ret;
+  *ret.mutable_var() = std::move(var);
+
+  return ret;
 }
 
 std::unique_ptr<Var> Var::from_proto(const gpb::Var& vproto) noexcept {
   return std::make_unique<Var>(vproto.name());
 }
 
-std::unique_ptr<const gpb::Graph> Graph::to_proto() const noexcept {
-  auto [optype, opptr] = op->to_proto();
-  std::unique_ptr<const gpb::Graph> gproto(make_proto_graph(optype, opptr));
-  return gproto;
-}
+gpb::Graph Graph::to_proto() const noexcept { return op->to_proto(); }
 
 Graph Graph::from_proto(const gpb::Graph& gproto) noexcept {
   return Graph(op_from_proto(gproto));
@@ -252,7 +222,7 @@ absl::Status compute_graph_ad::to_file(const Graph& graph, fs::path path) {
 
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  const std::unique_ptr<const gpb::Graph> gproto = graph.to_proto();
+  const gpb::Graph gproto = graph.to_proto();
 
   {
     std::ofstream out_file(path);
@@ -260,7 +230,7 @@ absl::Status compute_graph_ad::to_file(const Graph& graph, fs::path path) {
       return absl::InvalidArgumentError(
           fmt::format("Could not open file {} for writing.", path.string()));
     }
-    const bool ok = gproto->SerializeToOstream(&out_file);
+    const bool ok = gproto.SerializeToOstream(&out_file);
     if (!ok)
       ret_status.Update(absl::AbortedError(
           fmt::format("Something went wrong while serializing Graph to file {}",

--- a/src/graph.h
+++ b/src/graph.h
@@ -31,6 +31,8 @@ under certain conditions: see LICENSE.
 
 namespace compute_graph_ad {
 
+namespace gpb = graph_proto;
+
 /// Inputs to a graph's eval function: a mapping from variable name to value.
 using Inputs = absl::flat_hash_map<std::string, float>;
 
@@ -52,14 +54,8 @@ class Op {
       const Inputs& inputs,
       Eigen::Map<Eigen::RowVectorXf>& grad_out) const noexcept = 0;
 
-  /// Retrieve a type-erased protobuf representation of the operation.
-  /// The first element of the pair is the protobuf enum that specifies
-  /// what operation has been serialized, the second element is a void
-  /// pointer to the corresponding protobuf class instance (e.g.
-  /// graph_proto::Sum).
-  /// The caller takes ownership of the pointer returned.
-  virtual std::pair<graph_proto::Graph::OpCase, void*> to_proto()
-      const noexcept = 0;
+  /// Retrieve a protobuf representation of the operation.
+  virtual gpb::Graph to_proto() const noexcept = 0;
 };
 
 /// A sum operation, with two operands that can be operations themselves.
@@ -76,10 +72,9 @@ class Sum : public Op {
       const Inputs& inputs,
       Eigen::Map<Eigen::RowVectorXf>& grad_out) const noexcept final;
 
-  std::pair<graph_proto::Graph::OpCase, void*> to_proto() const noexcept final;
+  gpb::Graph to_proto() const noexcept final;
 
-  static std::unique_ptr<Sum> from_proto(
-      const graph_proto::Sum& sproto) noexcept;
+  static std::unique_ptr<Sum> from_proto(const gpb::Sum& sproto) noexcept;
 };
 
 /// A multiplication operation, with two operands that can be operations
@@ -97,10 +92,9 @@ class Mul : public Op {
       const Inputs& inputs,
       Eigen::Map<Eigen::RowVectorXf>& grad_out) const noexcept final;
 
-  std::pair<graph_proto::Graph::OpCase, void*> to_proto() const noexcept final;
+  gpb::Graph to_proto() const noexcept final;
 
-  static std::unique_ptr<Mul> from_proto(
-      const graph_proto::Mul& mproto) noexcept;
+  static std::unique_ptr<Mul> from_proto(const gpb::Mul& mproto) noexcept;
 };
 
 /// A compute graph.
@@ -133,10 +127,10 @@ class Graph {
       const Inputs& inputs) const noexcept;
 
   /// Serialize this Graph instance into a corresponding protobuf object.
-  std::unique_ptr<const graph_proto::Graph> to_proto() const noexcept;
+  gpb::Graph to_proto() const noexcept;
 
   /// Deserialize a protobuf object into a Graph instance.
-  static Graph from_proto(const graph_proto::Graph& gproto) noexcept;
+  static Graph from_proto(const gpb::Graph& gproto) noexcept;
 };
 
 /// A scalar constant.
@@ -183,9 +177,8 @@ class Const : public Op {
       const Inputs& inputs,
       Eigen::Map<Eigen::RowVectorXf>& grad_out) const noexcept final;
 
-  std::pair<graph_proto::Graph::OpCase, void*> to_proto() const noexcept final;
-  static std::unique_ptr<Const> from_proto(
-      const graph_proto::Const& cproto) noexcept;
+  gpb::Graph to_proto() const noexcept final;
+  static std::unique_ptr<Const> from_proto(const gpb::Const& cproto) noexcept;
 };
 
 /// A scalar variable: a value-less, named placeholder for a variable in the
@@ -250,10 +243,9 @@ class Var : public Op {
       const Inputs& inputs,
       Eigen::Map<Eigen::RowVectorXf>& grad_out) const noexcept final;
 
-  std::pair<graph_proto::Graph::OpCase, void*> to_proto() const noexcept final;
+  gpb::Graph to_proto() const noexcept final;
 
-  static std::unique_ptr<Var> from_proto(
-      const graph_proto::Var& vproto) noexcept;
+  static std::unique_ptr<Var> from_proto(const gpb::Var& vproto) noexcept;
 };
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
With this commit each operation creates the right
graph_proto::Graph and returns it by value,
taking advantage of move semantics and RVO to
avoid unnecessary copies.